### PR TITLE
rename the beautify method to better capture the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The library can be used in a declarative way, by adding the `data-showsource` at
 It is also possible to use the library from Javascript. So, we can use it to extract the HTML code from an element in a beautiful format (i.e. with indentation and line breaks). Then we can use the result to show it in a dialog, or to add it to the document in a different way.
 
 The library will be available in the global variable `showsource` with the following methods:
-- `showsource.beautify(el, userOptions = {}, indent = "")` - returns a list of strings with the HTML source code of the element `el` and its children. The `userOptions` parameter is optional and allows to customize the behavior of the function. The `indent` parameter is optional and is used to indent the source code.
+- `showsource.extract(el, userOptions = {}, indent = "")` - returns a list of strings with the HTML source code of the element `el` and its children. The `userOptions` parameter is optional and allows to customize the behavior of the function. The `indent` parameter is optional and is used to indent the source code.
 
 - `showsource.init()` - discovers any element with the `data-showsource` attribute and adds the source code of the element after it. The function returns the list of elements that have been processed.
 
@@ -64,7 +64,7 @@ An example of usage is shown below:
 ```javascript
 // get the element that we want to extract the html content
 const el = document.querySelector(".example");
-let lines = showsource.beautify(el);
+let lines = showsource.extract(el);
 
 // add the source code to the document
 el.insertAdjacentHTML("afterend", `<pre><code>${lines.join("\n")}</code></pre>`);
@@ -72,7 +72,7 @@ el.insertAdjacentHTML("afterend", `<pre><code>${lines.join("\n")}</code></pre>`)
 
 ### Options
 
-The `showsource.beautify` method accepts an optional `userOptions` parameter that allows to customize the behavior of the function. The following options are available:
+The `showsource.extract` method accepts an optional `userOptions` parameter that allows to customize the behavior of the function. The following options are available:
 
 ```javascript
 {

--- a/js/showsource.js
+++ b/js/showsource.js
@@ -55,7 +55,7 @@ let defaultOptions = {
  * @param {*} indent, the indentation to be used (the spaces at the beginning of the line)
  * @returns 
  */
-function beautify(el, userOptions = {}, indent = "") {
+function extractCode(el, userOptions = {}, indent = "") {
 
     let elOptions = {};
     if (el.dataset.showsourceIndentation !== undefined) {
@@ -241,7 +241,7 @@ function beautify(el, userOptions = {}, indent = "") {
                         beautifulElement.push(indent + options.indentation + text);
                     }
                 } else {
-                    let beautifulChild = beautify(child, childOptions, indent + (options.hide?"":options.indentation));
+                    let beautifulChild = extractCode(child, childOptions, indent + (options.hide?"":options.indentation));
                     beautifulElement = beautifulElement.concat(beautifulChild);
                 }
             }
@@ -271,7 +271,7 @@ function init() {
         let container = document.createElement("div");
         let pre = document.createElement("pre");
         let code = document.createElement("code");
-        code.textContent = beautify(el).join("\n");
+        code.textContent = extractCode(el).join("\n");
         pre.appendChild(code);
         container.appendChild(pre);
 
@@ -291,7 +291,7 @@ if (document.addEventListener) {
 
 window.showsource = {
     defaults: Object.assign({}, defaultOptions),
-    beautify: beautify,
+    extract: extractCode,
     init: init,
     version: "1.1.1"
 }


### PR DESCRIPTION
The main method was named `beautify`, but the main task was not to beautify the code: the main task is to extract the code to be used elsewhere (and it also beautifies the code). So I have renamed that method to `extract`